### PR TITLE
fix: emoji绘制异常，具体表现为RGBA通道问题，在入参函数进行规避方案

### DIFF
--- a/tester/harmony/skia/src/main/cpp/skia/JsiSkParagraphBuilder.h
+++ b/tester/harmony/skia/src/main/cpp/skia/JsiSkParagraphBuilder.h
@@ -32,99 +32,99 @@ namespace para = skia::textlayout;
  */
 class JsiSkParagraphBuilder : public JsiSkHostObject {
 public:
-  JSI_API_TYPENAME("ParagraphBuilder");
+    JSI_API_TYPENAME("ParagraphBuilder");
 
-  JSI_HOST_FUNCTION(build) {
-    return jsi::Object::createFromHostObject(
-        runtime,
-        std::make_shared<JsiSkParagraph>(getContext(), _builder.get()));
-  }
-
-  JSI_HOST_FUNCTION(reset) {
-    _builder->Reset();
-    return jsi::Value::undefined();
-  }
-
-  JSI_HOST_FUNCTION(addText) {
-    auto text = getArgumentAsString(runtime, arguments, count, 0).utf8(runtime);
-    _builder->addText(text.c_str());
-    return thisValue.asObject(runtime);
-  }
-
-  JSI_HOST_FUNCTION(addPlaceholder) {
-    auto width =
-        count >= 1 ? getArgumentAsNumber(runtime, arguments, count, 0) : 0;
-    auto height =
-        count >= 2 ? getArgumentAsNumber(runtime, arguments, count, 1) : 0;
-    auto alignment =
-        count >= 3 ? static_cast<para::PlaceholderAlignment>(
-                         getArgumentAsNumber(runtime, arguments, count, 2))
-                   : para::PlaceholderAlignment::kBaseline;
-    auto baseline = count >= 4
-                        ? static_cast<para::TextBaseline>(
-                              getArgumentAsNumber(runtime, arguments, count, 3))
-                        : para::TextBaseline::kAlphabetic;
-    auto offset =
-        count >= 5 ? getArgumentAsNumber(runtime, arguments, count, 4) : 0;
-
-    para::PlaceholderStyle style(width, height, alignment, baseline, offset);
-    _builder->addPlaceholder(style);
-
-    return thisValue.asObject(runtime);
-  }
-
-  JSI_HOST_FUNCTION(pushStyle) {
-    auto textStyle = JsiSkTextStyle::fromValue(runtime, arguments[0]);
-    // Foreground paint
-    if (count >= 2) {
-      auto foreground =
-          tryGetArgumentAsHostObject<JsiSkPaint>(runtime, arguments, count, 1);
-      if (foreground) {
-        textStyle.setForegroundPaint(*foreground->getObject().get());
-      }
-    }
-    // Background paint
-    if (count >= 3) {
-      auto background =
-          tryGetArgumentAsHostObject<JsiSkPaint>(runtime, arguments, count, 2);
-      if (background) {
-        textStyle.setBackgroundPaint(*background->getObject().get());
-      }
+    JSI_HOST_FUNCTION(build) {
+        return jsi::Object::createFromHostObject(runtime,
+                                                 std::make_shared<JsiSkParagraph>(getContext(), _builder.get()));
     }
 
-    _builder->pushStyle(textStyle);
-
-    return thisValue.asObject(runtime);
-  }
-
-  JSI_HOST_FUNCTION(pop) {
-    _builder->pop();
-    return thisValue.asObject(runtime);
-  }
-
-  JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkParagraphBuilder, build),
-                       JSI_EXPORT_FUNC(JsiSkParagraphBuilder, reset),
-                       JSI_EXPORT_FUNC(JsiSkParagraphBuilder, addText),
-                       JSI_EXPORT_FUNC(JsiSkParagraphBuilder, addPlaceholder),
-                       JSI_EXPORT_FUNC(JsiSkParagraphBuilder, pushStyle),
-                       JSI_EXPORT_FUNC(JsiSkParagraphBuilder, pop))
-
-  explicit JsiSkParagraphBuilder(std::shared_ptr<RNSkPlatformContext> context,
-                                 para::ParagraphStyle paragraphStyle,
-                                 sk_sp<SkFontMgr> fontManager)
-      : JsiSkHostObject(std::move(context)) {
-    _fontCollection = sk_make_sp<para::FontCollection>();
-    auto fontMgr = JsiSkFontMgrFactory::getFontMgr(getContext());
-    _fontCollection->setDefaultFontManager(fontMgr);
-    if (fontManager != nullptr) {
-      _fontCollection->setAssetFontManager(fontManager);
+    JSI_HOST_FUNCTION(reset) {
+        _builder->Reset();
+        return jsi::Value::undefined();
     }
-    _fontCollection->enableFontFallback();
-    _builder = para::ParagraphBuilder::make(paragraphStyle, _fontCollection);
-  }
+
+    JSI_HOST_FUNCTION(addText) {
+        auto text = getArgumentAsString(runtime, arguments, count, 0).utf8(runtime);
+        auto tctr = text.c_str();
+        _builder->addText(text.c_str());
+        LOG(ERROR) << "liwang c++ ParagraphBuilder.addText 添加文本---->" << tctr;
+        return thisValue.asObject(runtime);
+    }
+
+    JSI_HOST_FUNCTION(addPlaceholder) {
+        auto width = count >= 1 ? getArgumentAsNumber(runtime, arguments, count, 0) : 0;
+        auto height = count >= 2 ? getArgumentAsNumber(runtime, arguments, count, 1) : 0;
+        auto alignment =
+            count >= 3 ? static_cast<para::PlaceholderAlignment>(getArgumentAsNumber(runtime, arguments, count, 2))
+                       : para::PlaceholderAlignment::kBaseline;
+        auto baseline = count >= 4 ? static_cast<para::TextBaseline>(getArgumentAsNumber(runtime, arguments, count, 3))
+                                   : para::TextBaseline::kAlphabetic;
+        auto offset = count >= 5 ? getArgumentAsNumber(runtime, arguments, count, 4) : 0;
+
+        para::PlaceholderStyle style(width, height, alignment, baseline, offset);
+        _builder->addPlaceholder(style);
+
+        return thisValue.asObject(runtime);
+    }
+
+    JSI_HOST_FUNCTION(pushStyle) {
+        auto textStyle = JsiSkTextStyle::fromValue(runtime, arguments[0]);
+        
+        // Foreground paint
+        if (count >= 2) {
+            auto foreground = tryGetArgumentAsHostObject<JsiSkPaint>(runtime, arguments, count, 1);
+            if (foreground) {
+                textStyle.setForegroundPaint(*foreground->getObject().get());
+            }
+        }
+        // Background paint
+        if (count >= 3) {
+            auto background = tryGetArgumentAsHostObject<JsiSkPaint>(runtime, arguments, count, 2);
+            if (background) {
+                textStyle.setBackgroundPaint(*background->getObject().get());
+            }
+        }
+        
+        // RGBA
+        if (textStyle.getColor() == SK_ColorWHITE && (!textStyle.hasForeground() || !textStyle.getForeground().getColorFilter())) {
+            SkPaint paint = SkPaint();
+            float matrix[20] = {0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0};
+            sk_sp<SkColorFilter> colorFilter = SkColorFilters::Matrix(std::move(matrix));
+            paint.setColorFilter(colorFilter);
+            textStyle.setForegroundPaint(paint);
+        }
+        
+        _builder->pushStyle(textStyle);
+
+        return thisValue.asObject(runtime);
+    }
+
+    JSI_HOST_FUNCTION(pop) {
+        _builder->pop();
+        return thisValue.asObject(runtime);
+    }
+
+    JSI_EXPORT_FUNCTIONS(JSI_EXPORT_FUNC(JsiSkParagraphBuilder, build), JSI_EXPORT_FUNC(JsiSkParagraphBuilder, reset),
+                         JSI_EXPORT_FUNC(JsiSkParagraphBuilder, addText),
+                         JSI_EXPORT_FUNC(JsiSkParagraphBuilder, addPlaceholder),
+                         JSI_EXPORT_FUNC(JsiSkParagraphBuilder, pushStyle), JSI_EXPORT_FUNC(JsiSkParagraphBuilder, pop))
+
+    explicit JsiSkParagraphBuilder(std::shared_ptr<RNSkPlatformContext> context, para::ParagraphStyle paragraphStyle,
+                                   sk_sp<SkFontMgr> fontManager)
+        : JsiSkHostObject(std::move(context)) {
+        _fontCollection = sk_make_sp<para::FontCollection>();
+        auto fontMgr = JsiSkFontMgrFactory::getFontMgr(getContext());
+        _fontCollection->setDefaultFontManager(fontMgr);
+        if (fontManager != nullptr) {
+            _fontCollection->setAssetFontManager(fontManager);
+        }
+        _fontCollection->enableFontFallback();
+        _builder = para::ParagraphBuilder::make(paragraphStyle, _fontCollection);
+    }
 
 private:
-  std::unique_ptr<para::ParagraphBuilder> _builder;
-  sk_sp<para::FontCollection> _fontCollection;
+    std::unique_ptr<para::ParagraphBuilder> _builder;
+    sk_sp<para::FontCollection> _fontCollection;
 };
 } // namespace RNSkia


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- emoji绘制时RGBA通道中的R和B位置有问题。规避方案为：在添加文本样式的函数处添加默认正确的colorfilter，在设置colorfilter的函数处对RGBA有问题的地方进行位置调整。

## Test Plan

https://github.com/react-native-oh-library/RNOHDCS/blob/main/react-native-skia/tester/skiaDemoCases/components/Issuse_EmojiRGBAColorMartix.tsx

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
