### PR TITLE
fix: 沙箱路径读取文件，需去掉路径前面的file://字符串

### DIFF
--- a/tester/harmony/skia/src/main/cpp/rnskia/HarmonyPlatformContext.cpp
+++ b/tester/harmony/skia/src/main/cpp/rnskia/HarmonyPlatformContext.cpp
@@ -375,14 +375,17 @@ sk_sp<SkImage> HarmonyPlatformContext::takeScreenshotFromViewTag(size_t tag) {
 // 读取文件数据
 std::vector<uint8_t> HarmonyPlatformContext::ReadFileData(const std::string &sourceUri) {
     std::vector<uint8_t> buffer;
-
-    if (access(sourceUri.c_str(), F_OK) != 0) {
-        DLOG(ERROR) << "File does not exist: " << sourceUri << std::endl;
+    DLOG(INFO) << "File sourceUri: " << sourceUri << std::endl;
+    // 去掉路径前面的file://
+    std::string sourceUriObj = sourceUri.substr(7);
+    DLOG(INFO) << "File sourceUriObj: " << sourceUriObj << std::endl;
+    if (access(sourceUriObj.c_str(), F_OK) != 0) {
+        DLOG(ERROR) << "File does not exist: " << sourceUriObj << std::endl;
         return buffer;
     }
-    std::ifstream file(sourceUri, std::ios::binary | std::ios::ate);
+    std::ifstream file(sourceUriObj, std::ios::binary | std::ios::ate);
     if (!file) {
-        DLOG(ERROR) << "Failed to open file: " << sourceUri << std::endl;
+        DLOG(ERROR) << "Failed to open file: " << sourceUriObj << std::endl;
         return buffer;
     }
     std::streamsize size = file.tellg();
@@ -390,7 +393,7 @@ std::vector<uint8_t> HarmonyPlatformContext::ReadFileData(const std::string &sou
     file.seekg(0, std::ios::beg); // 回到文件头
     // 读取文件内容到buffer中
     if (!file.read(reinterpret_cast<char *>(buffer.data()), size)) {
-        DLOG(ERROR) << "Failed to read file: " << sourceUri << std::endl;
+        DLOG(ERROR) << "Failed to read file: " << sourceUriObj << std::endl;
         buffer.clear();
     }
     return buffer;


### PR DESCRIPTION

# Summary

fix: 沙箱路径读取文件，需去掉路径前面的file://字符串

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

