### PR TITLE
refactor:暴漏的接口和77版本RNCSkiaDomView保持一致

### DIFF
--- a/harmony/skia/index.ets
+++ b/harmony/skia/index.ets
@@ -22,5 +22,5 @@
  * SOFTWARE.
  */
 
-export * from "./src/main/ets/RNCSkiaPictureView"
+export * from "./src/main/ets/RNCSkiaDomView"
 export * from "./ts";

--- a/harmony/skia/src/main/cpp/rnskia/RNSkHarmonyVideo.cpp
+++ b/harmony/skia/src/main/cpp/rnskia/RNSkHarmonyVideo.cpp
@@ -616,15 +616,15 @@ double RNSkHarmonyVideo::framerate() {
 
 void RNSkHarmonyVideo::seek(double timestamp) {
     int64_t time;
-     DLOG(INFO) << "seek enter 跳转时间（毫秒）: " << timestamp;
     if (timestamp == 0) {
         DLOG(INFO) << "seek demuxer loop timestamp: " << timestamp;
         time = timestamp;
     } else {
-        time = static_cast<int64_t>(timestamp);
-        DLOG(INFO) << "seek 跳转时间（毫秒）: " << time << " 当前时间（毫秒）: " << milliseconds;
+        time = static_cast<int64_t>(timestamp) + milliseconds;
+        DLOG(INFO) << "seek enter  跳转时间（毫秒）: " << time << " 当前时间（毫秒）: " << milliseconds;
     }
-    int32_t ret = OH_AVDemuxer_SeekToTime(demuxer_->demuxer, time, OH_AVSeekMode::SEEK_MODE_PREVIOUS_SYNC);
+    DLOG(INFO) << "seek demuxer timestamp: " << timestamp;
+    int32_t ret = OH_AVDemuxer_SeekToTime(demuxer_->demuxer, time, OH_AVSeekMode::SEEK_MODE_CLOSEST_SYNC);
     if (ret != AV_ERR_OK) {
         DLOG(ERROR) << "seek demuxer loop failed";
         return;

--- a/harmony/skia/src/main/ets/RNCSkiaDomView.ets
+++ b/harmony/skia/src/main/ets/RNCSkiaDomView.ets
@@ -39,14 +39,14 @@ export interface SkiaPictureViewProps extends ViewRawProps {
   opaque: boolean
 }
 
-export const SKIA_PICTURE_VIEW_TYPE: string = "SkiaPictureView";
+export const SKIA_DOM_VIEW_TYPE: string = "SkiaPictureView";
 
 export type SkiaPictureViewDescriptor = Descriptor<"SkiaPictureView", ViewBaseProps, SkiaPictureViewState, SkiaPictureViewProps>
 
 const TAG: string = 'RNOH in SkiaPictureView'
 
 @Component
-export struct RNCSkiaPictureView {
+export struct RNCSkiaDomView {
   ctx!: RNOHContext;
   tag: number = -1;
   @State descriptor: SkiaPictureViewDescriptor = {} as SkiaPictureViewDescriptor;


### PR DESCRIPTION
# Summary

- refactor:暴漏的接口和77版本RNCSkiaDomView保持一致


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)